### PR TITLE
Exercise 2 fixes for psycopg2 version

### DIFF
--- a/exercise_2/Exercise-2.md
+++ b/exercise_2/Exercise-2.md
@@ -60,7 +60,7 @@ In this section, we provide the overall guidelines for implementing the system s
 	* **AMI ID: ami-d4dd4ec3**
 	
 	Also attach and mount the EBS volume at /data.
-3. Install **psycopg** by running: `$ pip install psycopg2`
+3. Install **psycopg** by running: `$ pip install psycopg2==2.6.2`
 4. Create a project called **extweetwordcount** with Streamparse (see Lab 6 for details)
 5. Copy the files from the **tweetwordcount** directory of the repository, and place them in the corresponding folders of the new **extweetwordcount** project. The description of the files in the code base is provided in Table 1.
 6. Modify the **extweetwordcound.clj** to implement the topology in Figure 1.

--- a/exercise_2/psycopg-sample.py
+++ b/exercise_2/psycopg-sample.py
@@ -1,38 +1,36 @@
 #Sample code snippets for working with psycopg
 
 
-#Connecting to a database
-#Note: If the database does not exist, then this command will create the database
-
-
 import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+# Connect to the database
 conn = psycopg2.connect(database="postgres", user="postgres", password="pass", host="localhost", port="5432")
 
 #Create the Database
 
 try:
+	# CREATE DATABASE can't run inside a transaction
+	conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     cur = conn.cursor()
-    cur.execute("CREATE DATABASE Tcount")
+    cur.execute("CREATE DATABASE tcount")
     cur.close()
-    conn.commit()
     conn.close()
 except:
-    print "Could not create Tcount"​
+    print "Could not create tcount"​
 
-#Connecting to Tcount
+#Connecting to tcount
 
-conn = psycopg2.connect(database="Tcount", user="postgres", password="pass", host="localhost", port="5432")
+conn = psycopg2.connect(database="tcount", user="postgres", password="pass", host="localhost", port="5432")
 
 #Create a Table
 #The first step is to create a cursor. 
 
 cur = conn.cursor()
-cur.execute('''CREATE TABLE Tweetwordcount
+cur.execute('''CREATE TABLE tweetwordcount
        (word TEXT PRIMARY KEY     NOT NULL,
        count INT     NOT NULL);''')
 conn.commit()
-conn.close()
 
 
 #Running sample SQL statements
@@ -45,17 +43,18 @@ conn.close()
 cur = conn.cursor()
 
 #Insert
-cur.execute("INSERT INTO Tweetwordcount (word,count) \
+cur.execute("INSERT INTO tweetwordcount (word,count) \
       VALUES ('test', 1)");
 conn.commit()
 
-#Update
-#Assuming you are passing the tuple (uWord, uCount) as an argument
-cur.execute("UPDATE Tweetwordcount SET count=%s WHERE word=%s", (uWord, uCount))
+#Using variables to update
+uCount=5
+uWord="test"
+cur.execute("UPDATE tweetwordcount SET count=%s WHERE word=%s", (uCount, uWord))
 conn.commit()
 
 #Select
-cur.execute("SELECT word, count from Tweetwordcount")
+cur.execute("SELECT word, count from tweetwordcount")
 records = cur.fetchall()
 for rec in records:
    print "word = ", rec[0]

--- a/exercise_2/psycopg-sample.py
+++ b/exercise_2/psycopg-sample.py
@@ -10,14 +10,14 @@ conn = psycopg2.connect(database="postgres", user="postgres", password="pass", h
 #Create the Database
 
 try:
-	# CREATE DATABASE can't run inside a transaction
-	conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    # CREATE DATABASE can't run inside a transaction
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     cur = conn.cursor()
     cur.execute("CREATE DATABASE tcount")
     cur.close()
     conn.close()
 except:
-    print "Could not create tcount"​
+    print "Could not create tcount"
 
 #Connecting to tcount
 


### PR DESCRIPTION
Updated the assignment doc to specify pip install psycopg2==2.6.2. Also found some bugs in psycopg-sample.py:

* CREATE DATABASE can't happen in a transaction, so I set the isolation level to autocommit for that section.
* The code was closing conn after the CREATE TABLE and not re-opening it before the other queries. Removed the close.
* Manually created uCount and uWord variables for the UPDATE, since there was no mechanism in the script to actually pass them in. Also they were in the wrong order in the list.

Script ran without error.